### PR TITLE
添加Claude 4模型支持

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -27,6 +27,22 @@
         }
     },
     "models": {
+        "claude-opus-4-20250514": {
+            "name": "Claude 4 Opus",
+            "provider": "anthropic",
+            "supportsMultimodal": true,
+            "isReasoning": true,
+            "version": "20250514",
+            "description": "最强大的Claude 4 Opus模型，支持图像理解和深度思考过程"
+        },
+        "claude-sonnet-4-20250514": {
+            "name": "Claude 4 Sonnet",
+            "provider": "anthropic",
+            "supportsMultimodal": true,
+            "isReasoning": true,
+            "version": "20250514",
+            "description": "高性能的Claude 4 Sonnet模型，支持图像理解和思考过程"
+        },
         "claude-3-7-sonnet-20250219": {
             "name": "Claude 3.7 Sonnet",
             "provider": "anthropic",

--- a/models/factory.py
+++ b/models/factory.py
@@ -1,4 +1,4 @@
-from typing import Dict, Type, Any
+from typing import Dict, Type, Any, Optional
 import json
 import os
 import importlib
@@ -81,7 +81,7 @@ class ModelFactory:
 
     @classmethod
     def create_model(cls, model_name: str, api_key: str, temperature: float = 0.7, 
-                     system_prompt: str = None, language: str = None, api_base_url: str = None) -> BaseModel:
+                     system_prompt: Optional[str] = None, language: Optional[str] = None, api_base_url: Optional[str] = None) -> BaseModel:
         """
         Create a model instance based on the model name.
         
@@ -128,6 +128,16 @@ class ModelFactory:
                 api_key=api_key,
                 temperature=temperature,
                 system_prompt=system_prompt
+            )
+        # 对于Anthropic模型，需要传递model_identifier参数
+        elif 'claude' in model_name.lower() or 'anthropic' in model_name.lower():
+            return model_class(
+                api_key=api_key,
+                temperature=temperature,
+                system_prompt=system_prompt,
+                language=language,
+                api_base_url=api_base_url,
+                model_identifier=model_name
             )
         else:
             # 其他模型仅传递标准参数
@@ -181,7 +191,7 @@ class ModelFactory:
     @classmethod
     def register_model(cls, model_name: str, model_class: Type[BaseModel], 
                       is_multimodal: bool = False, is_reasoning: bool = False,
-                      display_name: str = None, description: str = None) -> None:
+                      display_name: Optional[str] = None, description: Optional[str] = None) -> None:
         """
         Register a new model type with the factory.
         


### PR DESCRIPTION
- 在 `config/models.json` 中新增了 Claude 4 Opus 和 Claude 4 Sonnet 的模型配置，支持多模态和推理能力。
- 优化了 `models/anthropic.py`，支持动态选择模型标识符，完善了多模态推理和最大 Token 配置。
- 修改了 `models/factory.py`，使得 Anthropic 相关模型能够通过传递 model_identifier 参数进行动态选择，增强了模型工厂的扩展性。